### PR TITLE
Enable more netmiko arguments

### DIFF
--- a/napalm_procurve/procurve.py
+++ b/napalm_procurve/procurve.py
@@ -69,6 +69,8 @@ class ProcurveDriver(NetworkDriver):
             "alt_host_keys": False,
             "alt_key_file": "",
             "ssh_config_file": None,
+            "read_timeout_override": None,
+            "auth_timeout": None,
         }
 
         # Build dict of any optional Netmiko args


### PR DESCRIPTION
Add support for also overriding `read_timeout_override` and `read_timeout_override` netmiko arguments.